### PR TITLE
Context-dependent patterns

### DIFF
--- a/conf.d/_minimal_conf.fish
+++ b/conf.d/_minimal_conf.fish
@@ -1,0 +1,1 @@
+set -e fish_greeting

--- a/functions/_pisces_append.fish
+++ b/functions/_pisces_append.fish
@@ -1,5 +1,0 @@
-function _pisces_append -a text -d "Inserts a pair of strings (left-right) and puts the cursor between them"
-
-    commandline --insert $text
-    and _pisces_jump -(string length $text)
-end

--- a/functions/_pisces_bind_pair.fish
+++ b/functions/_pisces_bind_pair.fish
@@ -8,10 +8,10 @@ function _pisces_bind_pair -a left right -d "Creates bindings for the given pair
 
     if [ $left = $right ]
 
-        bind $r "_pisces_skip $right; or _pisces_append $right"
-    else # if $some_special_setting
+        bind $r "_pisces_skip $right; or _pisces_surround '' $right"
+    else
 
-        bind $l "commandline -i $left; and _pisces_append $right"
+        bind $l "_pisces_surround $left $right"
         bind $r "_pisces_skip $right"
     end
 end

--- a/functions/_pisces_match.fish
+++ b/functions/_pisces_match.fish
@@ -1,0 +1,12 @@
+function _pisces_match -a l_ctx r_ctx -d "Matches the context around the cursor with the given patterns (returns true/false)"
+
+    set buffer (commandline -b)
+    set cur (commandline -C)
+
+    set left  (string sub -l "$cur" "$buffer")
+    set right (string sub -s (math "$cur + 1") "$buffer")
+
+    string match -q -r $l_ctx'$' " $left"
+    and \
+    string match -q -r '^'$r_ctx "$right "
+end

--- a/functions/_pisces_surround.fish
+++ b/functions/_pisces_surround.fish
@@ -1,0 +1,5 @@
+function _pisces_surround -a left right -d "Inserts a pair of strings and puts the cursor between them"
+
+    commandline --insert "$left$right"
+    and _pisces_jump -(string length $right)
+end

--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,10 +1,40 @@
 function key_bindings
 
     set -q pisces_pairs
+    # or set -U pisces_pairs '(,)' '[,]' '{,}' '","' "','"
     or set -U pisces_pairs '(,)' '[,]' '{,}' '","' "','"
 
-    for pair in $pisces_pairs
-        _pisces_bind_pair (string split ',' $pair)
+    # for pair in $pisces_pairs
+    #     _pisces_bind_pair (string split ',' $pair)
+    # end
+
+    function pattern
+        string join \t $argv
+    end
+
+    set -q pisces_patterns
+    or set -U pisces_patterns \
+        (pattern '[^\w\\\]' '[' '\W' '[ ' ' ]') \
+        (pattern '[^\w\\\]' '"' '\W'  '"' '"') \
+        (pattern '[^\w\\\]' "'" '\W' "'" "'") \
+        (pattern 'for|if|switch'  ';'  '\W'  ' '  '; end;')
+        # (pattern 'for' ';' '\W' "\n" "\nend")
+        # (pattern 'begin'  ';'  '\W'  '; '  '; end;') \
+
+    function _pisces_bind_pattern -a l_ctx trg r_ctx l r
+        set lc (string escape -n $l_ctx)
+        set rc (string escape -n $r_ctx)
+
+        set l (string escape -n $l)
+        set r (string escape -n $r)
+
+        set t (string escape -n $trg)
+
+        bind $trg "_pisces_match $lc $rc; and _pisces_surround $l $r; or commandline -i $t"
+    end
+
+    for p in $pisces_patterns
+        _pisces_bind_pattern (string split \t $p)
     end
 
     # normal backspace, also known as \010 or ^H:


### PR DESCRIPTION
Instead of just pairs, I want to be able to define patterns.

- [ ] matching context around the cursor with regexes (left/right)
- [ ] surrounding cursor with arbitrary text (multi-character symbol-pairs)
- [ ] several pattern-pairs per trigger, i.e. different pairs depending on the context pattens which are bound to the same key (trigger)