### PR TITLE
Add Natural Selection integration

### DIFF
--- a/functions/_pisces_backspace.fish
+++ b/functions/_pisces_backspace.fish
@@ -1,5 +1,11 @@
 function _pisces_backspace -d "Overrides backspace to handle empty pairs removal"
 
+    # Natural Selection integration:
+    if functions -q _natural_selection_is_selecting; and _natural_selection_is_selecting
+        _natural_selection_kill_selection
+        return 0
+    end
+
     set -l line (commandline | string join \n)
     set -l index (commandline -C)
     if [ $index -ge 1 ]

--- a/functions/_pisces_bind_pair.fish
+++ b/functions/_pisces_bind_pair.fish
@@ -11,10 +11,10 @@ function _pisces_bind_pair -a mode left right -d "Creates bindings for the given
 
     if [ $left = $right ]
 
-        bind -M $mode $r "_pisces_skip $right; or _pisces_append $right"
+        bind -M $mode $l "_pisces_wrap $left $right"
     else
 
-        bind -M $mode $l "commandline -i -- $left; and _pisces_append $right"
+        bind -M $mode $l "_pisces_wrap $left $right"
         bind -M $mode $r "_pisces_skip $right"
     end
 end

--- a/functions/_pisces_skip.fish
+++ b/functions/_pisces_skip.fish
@@ -1,5 +1,11 @@
 function _pisces_skip -a text -d "Skips given text if it's already under the cursor"
 
+    # Natural Selection integration:
+    if functions -q _natural_selection_is_selecting; and _natural_selection_is_selecting
+        _natural_selection_replace_selection "$text"
+        return 0
+    end
+
     set length (string length -- $text)
 
     if [ (_pisces_lookup 0 $length) = $text ]

--- a/functions/_pisces_wrap.fish
+++ b/functions/_pisces_wrap.fish
@@ -1,0 +1,19 @@
+function _pisces_wrap -a left right -d "Wraps text with string pairs"
+
+    # Natural Selection integration:
+    if functions -q _natural_selection_is_selecting; and _natural_selection_is_selecting
+        _natural_selection_wrap_selection "$left" "$right"
+        return 0
+    end
+
+    set length (string length -- $left)
+
+    if [ $left = $right ]; and [ (_pisces_lookup -1 $length) = $left ]
+        _pisces_append $right
+        return 1
+    else
+        commandline -i -- $left
+        and _pisces_append $right
+        return 1
+    end
+end


### PR DESCRIPTION
Hopefully, this is a step towards solving issue #15.

I have created a plugin called [Natural Selection]. It tries to make the command line behave more like a text editor. Selection is the main focus because the native input functions don't behave as expected.

At this stage, it will require a little bit of work adding new shortcuts to your terminal. From memory, I had to add some extra escape sequences so I could target them with the new selection commands. Your mileage may vary. I would love some feedback how you found this process since I added extra key bindings in iTerm years ago, and I can no longer remember 😅

To get it working with pisces, you will need this fork and [Natural Selection] installed. Finally, modify the example key bindings by removing `$pairs` from `$characters` and removing the `$backspace` binding. This way it is handled by pisces.

I was going to create all of this for myself regardless if you wish to accept this integration or not, so don't feel like my efforts here is wasted if you decline. Anyway, take your time and I hope you enjoy it.

[Natural Selection]: https://github.com/daleeidd/natural-selection