### PR TITLE
Only insert completions if cursor is at EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Here `|` denotes the current cursor position. No manual cursor motion involved :
   `...|`
 - the set of pairs is configurable
 
+To disable completing pairs unless the cursor is at the end of the line, set
+the `$pisces_only_insert_at_eol` variable:
+
+```fish
+set -U pisces_only_insert_at_eol 1
+```
 
 ### Installation
 

--- a/functions/_pisces_bind_pair.fish
+++ b/functions/_pisces_bind_pair.fish
@@ -11,10 +11,10 @@ function _pisces_bind_pair -a mode left right -d "Creates bindings for the given
 
     if [ $left = $right ]
 
-        bind -M $mode $r "_pisces_skip $right; or _pisces_append $right"
+        bind -M $mode $r "_pisces_insert_identical $right"
     else
 
-        bind -M $mode $l "commandline -i -- $left; and _pisces_append $right"
-        bind -M $mode $r "_pisces_skip $right"
+        bind -M $mode $l "_pisces_insert_left $left $right"
+        bind -M $mode $r "_pisces_insert_right $right"
     end
 end

--- a/functions/_pisces_insert_identical.fish
+++ b/functions/_pisces_insert_identical.fish
@@ -1,0 +1,8 @@
+function _pisces_insert_identical -a text -d "The binding command for a pair where the left and right delimiters are identical"
+    if _pisces_should_insert $right
+        _pisces_skip $right
+        or _pisces_append $right
+    else
+        commandline -i -- $right
+    end
+end

--- a/functions/_pisces_insert_identical.fish
+++ b/functions/_pisces_insert_identical.fish
@@ -1,8 +1,8 @@
 function _pisces_insert_identical -a text -d "The binding command for a pair where the left and right delimiters are identical"
-    if _pisces_should_insert $right
-        _pisces_skip $right
-        or _pisces_append $right
+    if _pisces_should_insert $text
+        _pisces_skip $text
+        or _pisces_append $text
     else
-        commandline -i -- $right
+        commandline -i -- $text
     end
 end

--- a/functions/_pisces_insert_left.fish
+++ b/functions/_pisces_insert_left.fish
@@ -1,0 +1,5 @@
+function _pisces_insert_left -a left right -d "The binding command to insert the left delimiter"
+    commandline -i -- $left
+    and _pisces_should_insert $right
+    and _pisces_append $right
+end

--- a/functions/_pisces_insert_right.fish
+++ b/functions/_pisces_insert_right.fish
@@ -1,5 +1,7 @@
 function _pisces_insert_right -a right -d "The binding command to insert the right delimiter"
-    _pisces_should_insert $right
-    and _pisces_skip $right
-    or commandline -i -- $right
+    if _pisces_should_insert $right
+        _pisces_skip $right
+    else
+        commandline -i -- $right
+    end
 end

--- a/functions/_pisces_insert_right.fish
+++ b/functions/_pisces_insert_right.fish
@@ -1,0 +1,5 @@
+function _pisces_insert_right -a right -d "The binding command to insert the right delimiter"
+    _pisces_should_insert $right
+    and _pisces_skip $right
+    or commandline -i -- $right
+end

--- a/functions/_pisces_lookup.fish
+++ b/functions/_pisces_lookup.fish
@@ -9,6 +9,6 @@ function _pisces_lookup -a pos len -d "Returns the text at the given position re
     set input (commandline -b)
 
     # NOTE: it's important to quote $input, because it may have newlines
-    string sub --start (math "$cur + $pos + 1") --length $len -- "$input" ^/dev/null
+    string sub --start (math "$cur + $pos + 1") --length $len -- "$input" 2>/dev/null
     or echo '' # if it's out of bounds (probably better to return cut part)
 end

--- a/functions/_pisces_should_insert.fish
+++ b/functions/_pisces_should_insert.fish
@@ -1,0 +1,9 @@
+function _pisces_should_insert -a insert -d "Determines if we should insert text"
+    # If $pisces_only_insert_at_eol is unset, return true
+    # Otherwise, return true if the cursor is at the end of the line OR
+    # if the cursor is before a copy of $insert (i.e. a delimiter) at the end
+    # of the line.
+    test -z "$pisces_only_insert_at_eol" \
+        -o (commandline -c) = (commandline) \
+        -o (commandline -c)"$insert" = (commandline)
+end

--- a/functions/_pisces_should_insert.fish
+++ b/functions/_pisces_should_insert.fish
@@ -3,7 +3,9 @@ function _pisces_should_insert -a insert -d "Determines if we should insert text
     # Otherwise, return true if the cursor is at the end of the line OR
     # if the cursor is before a copy of $insert (i.e. a delimiter) at the end
     # of the line.
+    set cmd_to_cursor (commandline -c)
+    set cmd (commandline)
     test -z "$pisces_only_insert_at_eol" \
-        -o (commandline -c) = (commandline) \
-        -o (commandline -c)"$insert" = (commandline)
+        -o "$cmd_to_cursor" = "$cmd" \
+        -o "$cmd_to_cursor$insert" = "$cmd"
 end

--- a/functions/_pisces_skip.fish
+++ b/functions/_pisces_skip.fish
@@ -2,7 +2,7 @@ function _pisces_skip -a text -d "Skips given text if it's already under the cur
 
     set length (string length -- $text)
 
-    if [ (_pisces_lookup 0 $length) = $text ]
+    if test (_pisces_lookup 0 $length) = "$text"
         _pisces_jump $length
         return 0
     else


### PR DESCRIPTION
If the `pisces_only_insert_at_eol` variable is set, closing-delimiters will be inserted / skipped past only while the cursor is at the end of the line.

This helps when modifying a command like

    ls some directory

to quote an argument:

    ls "some directory"

With Pisces' default configuration, you'll get:

    ls ""some directory""

Closes issue #19.