### PR TITLE
Fix breakage when the `stderr-nocaret` feature flag is enabled.

### DIFF
--- a/functions/_pisces_lookup.fish
+++ b/functions/_pisces_lookup.fish
@@ -9,6 +9,6 @@ function _pisces_lookup -a pos len -d "Returns the text at the given position re
     set input (commandline -b)
 
     # NOTE: it's important to quote $input, because it may have newlines
-    string sub --start (math "$cur + $pos + 1") --length $len -- "$input" ^/dev/null
+    string sub --start (math "$cur + $pos + 1") --length $len -- "$input" 2>/dev/null
     or echo '' # if it's out of bounds (probably better to return cut part)
 end


### PR DESCRIPTION
When `stderr-nocaret` is on, the test in `pisces_skip.fish` fails by outputting a bunch of ugly junk, like so:

```
 ~/c/fish-shell    ls [: Expected a combining operator like '-a' at index 2                                                                                                             
e = '
^
~/.config/fish/functions/_pisces_skip.fish (line 5):
if [ (_pisces_lookup 0 $length) = $text ]
^
in function '_pisces_skip' with arguments '\''
''                                    ''
```

This makes pisces basically unusable, but fortunately there's a simple fix, attached here. We just have to change the use of the `^` redirection to `2>` in `pisces_lookup`.

As discussion is currently ongoing around enabling these flags by default in a subsequent release (see https://github.com/fish-shell/fish-shell/issues/7105), it seems timely to fix this.